### PR TITLE
order tags displayed in dropdown

### DIFF
--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -65,29 +65,31 @@ export default class TagEntityView extends React.Component {
   };
 
   getTagKeys = () => {
-    const { tagHierarchy, orderedTags, tagsObject } = this.props;
+    const { tagHierarchy, tagsObject } = this.props;
 
     let tagsForDropdown = [];
-    tagsForDropdown.push({
-      title: 'required',
-      array: tagsObject.required,
-      items: []
-    });
-    tagsForDropdown.push({
-      title: 'optional',
-      array: tagsObject.optional,
-      items: []
-    });
-    tagsForDropdown.push({title: 'not in policy', array: [], items: []});
-    const lastTypeIdx = 2;
+    tagsForDropdown.push({ title: 'required', array: tagsObject.required });
+    tagsForDropdown.push({ title: 'optional', array: tagsObject.optional });
+    tagsForDropdown.push({ title: 'not in policy', array: [] });
 
-    Object.keys(tagHierarchy).map(tag => {
-      let idx = tagsForDropdown.findIndex(t => t.array.includes(tag));
-      if (idx < 0) idx = lastTypeIdx;
-      tagsForDropdown[idx].items.push(tag);
-    });
+    const items = Object.keys(tagHierarchy)
+      .reduce(
+        (acc, tag) => {
+          let idx = tagsForDropdown.findIndex(t => t.array.includes(tag));
+          if (idx < 0) idx = 2; //push into 'not in policy'
+          acc[idx].push(tag);
+          return acc;
+        },
+        [[], [], []]
+      )
+      .map(tags =>
+        tags.sort((tag1, tag2) =>
+          tag1.toLowerCase().localeCompare(tag2.toLowerCase())
+        )
+      );
 
-    tagsForDropdown.map(tagType => tagType.items = tagType.items.sort());
+    tagsForDropdown.map((section, i) => tagsForDropdown[i]['items'] = items[i]);
+    
     return tagsForDropdown;
   };
 

--- a/nerdlets/tag-improver-nerdlet/index.js
+++ b/nerdlets/tag-improver-nerdlet/index.js
@@ -371,9 +371,8 @@ function sortedPolicy(policy) {
 }
 
 function tagsObject(policy) {
-  return (policy || []).reduce((acc, cur) => {
-    if (!(cur.enforcement in acc)) acc[cur.enforcement] = [];
-    acc[cur.enforcement].push(cur.key);
-    return acc;
-  }, {});
+  return (policy || []).reduce(
+    (acc, cur) => Object.assign(acc, acc[cur.enforcement].push(cur.key)),
+    { required: [], optional: [] }
+  );
 }


### PR DESCRIPTION
Fixes #7 

- passing schema to TagEntityView as `tagsObject` prop, broken down by enforcement level
- `getTagKeys` fn updated to return an array of sections, each section containing tags under a specific enforcement level
- using `DropdownSection` component to break up dropdown into sections  (each section contains tags for an enforcement levels)