### PR TITLE
fixes #31  Improve height management of side-by-side tables in TagCoverageView

### DIFF
--- a/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
@@ -53,8 +53,8 @@ export default class TagCoverageView extends React.Component {
       Object.keys(tagHierarchy[currentTagGroup]).length > 0;
 
     return (
-      <div className="split">
-      <Grid className="primary-grid">
+      <div className="split" style={{ height: (this.props.height || 1200) - 120 }}>
+      <Grid className="primary-grid" style={{alignContent: "start"}}>
         <GridItem className="primary-content-container" columnSpan={7}>
           <HeadingText type={HeadingText.TYPE.HEADING_4}>
             Tags in use
@@ -87,6 +87,10 @@ export default class TagCoverageView extends React.Component {
             breakdown
           </HeadingText>
         </GridItem>
+
+        <GridItem className="primary-content-container" columnSpan={12}>
+          <hr/>
+              </GridItem>
 
         <GridItem className="primary-content-container" columnSpan={7}>
           <div className="left">

--- a/nerdlets/tag-improver-nerdlet/index.js
+++ b/nerdlets/tag-improver-nerdlet/index.js
@@ -160,6 +160,7 @@ export default class TagVisualizer extends React.Component {
                   entityCount={selectedEntityType.id === "all" ? entityCount : entityTypesEntityCount[selectedEntityType.value]}
                   loadedEntities={loadedEntities}
                   doneLoading={doneLoading}
+                  height={this.props.height}
                 />
               </TabsItem>
               <TabsItem value="entity-tab" label="Entities">

--- a/nerdlets/tag-improver-nerdlet/styles.scss
+++ b/nerdlets/tag-improver-nerdlet/styles.scss
@@ -74,7 +74,7 @@ div[class$='-wnd-TabContent'] {
 
 .split {
     width: 100%;
-    height: 1200px;
+    // height: 1200px;
     display: flex;
 }
 .left {

--- a/nerdlets/tag-improver-nerdlet/tag-schema.js
+++ b/nerdlets/tag-improver-nerdlet/tag-schema.js
@@ -57,4 +57,21 @@ const SCHEMA = [
   }
 ];
 
-export { SCHEMA, TAG_SCHEMA_ENFORCEMENT, ENFORCEMENT_PRIORITY, COMPLIANCEBANDS };
+const ENTITY_TYPES = [
+  // { id: "all", name: "All Entity Types", value: "ALL_ENTITIES" },
+  { id: "APM", name: "Application", value: "APM_APPLICATION_ENTITY" },
+  { id: "BROWSER", name: "Browser", value: "BROWSER_APPLICATION_ENTITY" },
+  { id: "MOBILE", name: "Mobile", value: "MOBILE_APPLICATION_ENTITY" },
+  { id: "INFRA", name: "Infrastructure", value: "INFRASTRUCTURE_HOST_ENTITY" },
+  { id: "SYNTH", name: "Synthetic", value: "SYNTHETIC_MONITOR_ENTITY" },
+  { id: "VIZ", name: "Dashboard", value: "DASHBOARD_ENTITY" },
+  { id: "NR1", name: "Workload", value: "WORKLOAD_ENTITY" }
+];
+
+export {
+  SCHEMA,
+  TAG_SCHEMA_ENFORCEMENT,
+  ENFORCEMENT_PRIORITY,
+  COMPLIANCEBANDS,
+  ENTITY_TYPES
+};


### PR DESCRIPTION
- used `this.props.height` to determine the height of the container with side by side table to be able to scroll them independently
- added inline style alignContent: "start" to ensure tables start from the top of their containers
