### PR TITLE
fix: entities table - tags wrapping, make icon smaller, change checkb…

### DIFF
--- a/nerdlets/tag-improver-nerdlet/components/exclamation.svg
+++ b/nerdlets/tag-improver-nerdlet/components/exclamation.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="15px" height="15px" viewBox="0 0 15 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="10px" height="10px" viewBox="0 0 15 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>Interface / Sign / Exclamation Alternate</title>
     <g id="2.0-Refinements" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="1.0-Tag-policy" transform="translate(-292.000000, -721.000000)" fill="#000E0E">

--- a/nerdlets/tag-improver-nerdlet/components/green-checkmark.svg
+++ b/nerdlets/tag-improver-nerdlet/components/green-checkmark.svg
@@ -1,5 +1,5 @@
 <svg version="1.0" xmlns="http://www.w3.org/2000/svg"
- width="15px" height="15px" viewBox="0 0 127.000000 117.000000"
+ width="12px" height="12px" viewBox="0 0 127.000000 117.000000"
  preserveAspectRatio="xMidYMid meet">
 <g transform="translate(0.000000,117.000000) scale(0.100000,-0.100000)"
 fill="green" stroke="none">

--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -35,7 +35,7 @@ export default class TagEntityView extends React.Component {
     table_column_1: TableHeaderCell.SORTING_TYPE.ASCENDING,
     selectedEntities: {},
     selectedEntityIds: [],
-    includeDefinedTags: false
+    showAllTags: false
   };
 
   componentDidMount() {
@@ -144,9 +144,9 @@ export default class TagEntityView extends React.Component {
   };
 
   onCheckboxChange = event => {
-    const includeDefinedTags = event.target.checked;
+    const showAllTags = event.target.checked;
 
-    this.setState({ includeDefinedTags });
+    this.setState({ showAllTags });
   }
 
   render() {
@@ -155,7 +155,7 @@ export default class TagEntityView extends React.Component {
       firstTagKey,
       selectedEntities,
       selectedEntityIds,
-      includeDefinedTags
+      showAllTags
     } = this.state;
     const { tagHierarchy, entityTagsMap, reloadTagsFn } = this.props;
     const tagKeys = this.getTagKeys();
@@ -213,9 +213,9 @@ export default class TagEntityView extends React.Component {
           </div>
           <div>
             <Checkbox
-              checked={this.state.includeDefinedTags}
+              checked={this.state.showAllTags}
               onChange={this.onCheckboxChange}
-              label="Include Defined Tags"
+              label="Show all policy tags"
             />
           </div>
           <div className="button-section" style={{ padding: 8 }}>
@@ -311,10 +311,10 @@ export default class TagEntityView extends React.Component {
                 Score
               </TableHeaderCell>
               <TableHeaderCell width="6fr">
-                {includeDefinedTags ? '' : 'Undefined'} Mandatory Tags
+                {showAllTags ? '' : 'Undefined'} Mandatory Tags
               </TableHeaderCell>
               <TableHeaderCell width="7fr">
-              {includeDefinedTags ? '' : 'Undefined'} Optional Tags
+              {showAllTags ? '' : 'Undefined'} Optional Tags
               </TableHeaderCell>
             </TableHeader>
 
@@ -333,11 +333,11 @@ export default class TagEntityView extends React.Component {
                 >
                   {`${item.complianceScore.toFixed(2)}%`}
                 </TableRowCell>
-                <TableRowCell>
-                  <TagListing type="mandatory" tags={item.mandatoryTags} includeDefinedTags={includeDefinedTags} />
+                <TableRowCell className="tag_nowrap_table_cell">
+                  <TagListing type="mandatory" tags={item.mandatoryTags} showAllTags={showAllTags} />
                 </TableRowCell>
-                <TableRowCell>
-                  <TagListing type="optional" tags={item.optionalTags} includeDefinedTags={includeDefinedTags} />
+                <TableRowCell className="tag_nowrap_table_cell">
+                  <TagListing type="optional" tags={item.optionalTags} showAllTags={showAllTags} />
                 </TableRowCell>
               </TableRow>
             )}

--- a/nerdlets/tag-improver-nerdlet/components/tag-listing.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-listing.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import bang from './exclamation.svg';
 import check from './green-checkmark.svg';
 
-const TagListing = ({ type, tags, includeDefinedTags }) => {
+const TagListing = ({ type, tags, showAllTags }) => {
   const passes = []
   const fails = []
 
@@ -65,7 +65,7 @@ const TagListing = ({ type, tags, includeDefinedTags }) => {
       {/* <label className="tags__title">{type}</label> */}
       <div className="tags__list">
         {renderTags(fails)}
-        {includeDefinedTags ? renderTags(passes) : ''}
+        {showAllTags ? renderTags(passes) : ''}
       </div>
     </div>
   );
@@ -74,7 +74,7 @@ const TagListing = ({ type, tags, includeDefinedTags }) => {
 TagListing.propTypes = {
   type: PropTypes.string.isRequired,
   tags: PropTypes.array.isRequired,
-  includeDefinedTags: PropTypes.bool.isRequired,
+  showAllTags: PropTypes.bool.isRequired,
 };
 
 export default TagListing;

--- a/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
+++ b/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
@@ -25,7 +25,13 @@ $low-band-color: rgb(191, 0, 22);
 
 .tags__list {
   display: flex;
-  flex-wrap: wrap;
+  // flex-wrap: wrap;
+}
+
+.tag_nowrap_table_cell {
+  div {
+    text-overflow: clip;
+  }
 }
 
 .tags__tag {


### PR DESCRIPTION
this PR is an extension to issue #22 "Add score and matrix to entities table".
- improves tasg visualization in entities table by showing tags in one line and hiding the overflow that wouldn't fit in in the cell width. it removes NR1 table default behavior of showing ellipsis when content overflows
- make "!" and "✓" icons smaller in the table
- change checkbox label on top to "Show all policy tags"
