### PR TITLE
V1.1 tag analyzer links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tmp
 .env
 .env.test
 .cache
+package-lock.json

--- a/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
@@ -130,7 +130,7 @@ export default class TagCoverageView extends React.Component {
           </GridItem>
           <GridItem className="primary-content-container" columnSpan={4}>
             <HeadingText type={HeadingText.TYPE.HEADING_4}>
-              Tag
+              Values in use for
               <Dropdown
                 title={currentTagGroup}
                 items={tagKeys}
@@ -158,7 +158,7 @@ export default class TagCoverageView extends React.Component {
                   </DropdownSection>
                 )}
               </Dropdown>
-              breakdown
+              tag
             </HeadingText>
           </GridItem>
 

--- a/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
@@ -20,8 +20,10 @@ export default class TagCoverageView extends React.Component {
     entityCount: PropTypes.number,
     tagHierarchy: PropTypes.object,
     taggingPolicy: PropTypes.array,
-    getTagKeys: PropTypes.object,
-    height: PropTypes.number
+    getTagKeys: PropTypes.array,
+    height: PropTypes.number,
+    onUpdateEntitiesFilter: PropTypes.func,
+    onShowEntities: PropTypes.func
   };
 
   state = {
@@ -29,6 +31,10 @@ export default class TagCoverageView extends React.Component {
   };
 
   updateCurrentTagGroup = currentTagGroup => {
+    this.props.onUpdateEntitiesFilter({
+      tagKey: currentTagGroup,
+      tagValue: null
+    });
     this.setState({ currentTagGroup });
   };
 
@@ -57,7 +63,7 @@ export default class TagCoverageView extends React.Component {
         const coverage = Math.floor((count * 100) / entityCount);
         const enforcement =
           (taggingPolicy.find(schema => schema.key === k) || {}).enforcement ||
-          'Non-Policy';
+          'non-policy';
         const enforcementPriority = enforcement
           ? ENFORCEMENT_PRIORITY[enforcement]
           : -1;
@@ -81,6 +87,7 @@ export default class TagCoverageView extends React.Component {
 
     return Object.keys(tagHierarchy[currentTagGroup]).map(v => {
       return {
+        tagKey: currentTagGroup,
         tagValue: v,
         entityCount: tagHierarchy[currentTagGroup][v].length
       };
@@ -162,7 +169,10 @@ export default class TagCoverageView extends React.Component {
           <GridItem className="primary-content-container" columnSpan={4}>
             {currentTagGroupIsPopulated ? (
               <div className="right">
-                <TagValueTable getTableData={() => getValueTableData()} />
+                <TagValueTable
+                  getTableData={() => getValueTableData()}
+                  onShowEntities={this.props.onShowEntities}
+                />
               </div>
             ) : (
               <></>

--- a/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
@@ -83,15 +83,24 @@ export default class TagCoverageView extends React.Component {
   getValueTableData = () => {
     const { tagHierarchy } = this.props;
     const { currentTagGroup } = this.state;
-    if (!tagHierarchy[currentTagGroup]) return [];
+    // if (!tagHierarchy[currentTagGroup]) return [];
 
-    return Object.keys(tagHierarchy[currentTagGroup]).map(v => {
+    const valueTableData = Object.keys(tagHierarchy[currentTagGroup]).map(v => {
       return {
         tagKey: currentTagGroup,
         tagValue: v,
         entityCount: tagHierarchy[currentTagGroup][v].length
       };
     });
+    const entityCount = valueTableData.reduce((acc, cur) => {
+      return acc + cur.entityCount;
+    }, 0);
+    valueTableData.push({
+      tagKey: currentTagGroup,
+      tagValue: '<not present>',
+      entityCount: this.props.entityCount - entityCount
+    });
+    return valueTableData;
   };
 
   render() {

--- a/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
@@ -53,6 +53,7 @@ export default class TagCoverageView extends React.Component {
   getTagTableData = () => {
     const { entityCount, tagHierarchy, taggingPolicy } = this.props;
     const { getSortedTagKeys } = this;
+    const { currentTagGroup } = this.state;
 
     return getSortedTagKeys(
       Object.keys(tagHierarchy).map(k => {
@@ -74,7 +75,8 @@ export default class TagCoverageView extends React.Component {
           enforcementPriority: enforcementPriority,
           cardinality: Object.keys(tagHierarchy[k]).length,
           entityCount: count,
-          entityPercent: coverage
+          entityPercent: coverage,
+          selected: k === currentTagGroup ? true : false // eslint-disable-line no-unneeded-ternary
         };
       })
     );
@@ -97,7 +99,7 @@ export default class TagCoverageView extends React.Component {
     }, 0);
     valueTableData.push({
       tagKey: currentTagGroup,
-      tagValue: '<not present>',
+      tagValue: '<tag not defined>',
       entityCount: this.props.entityCount - entityCount
     });
     return valueTableData;

--- a/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
@@ -61,7 +61,9 @@ export default class TagCoverageView extends React.Component {
           (acc, v) => acc + tagHierarchy[k][v].length,
           0
         );
-        const coverage = Math.floor((count * 100) / entityCount);
+        const coverage = !entityCount
+          ? 0
+          : Math.floor((count * 100) / entityCount);
         const enforcement =
           (taggingPolicy.find(schema => schema.key === k) || {}).enforcement ||
           'non-policy';

--- a/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-coverage.js
@@ -83,7 +83,7 @@ export default class TagCoverageView extends React.Component {
   };
 
   getValueTableData = () => {
-    const { tagHierarchy } = this.props;
+    const { tagHierarchy, taggingPolicy } = this.props;
     const { currentTagGroup } = this.state;
     // if (!tagHierarchy[currentTagGroup]) return [];
 
@@ -99,6 +99,9 @@ export default class TagCoverageView extends React.Component {
     }, 0);
     valueTableData.push({
       tagKey: currentTagGroup,
+      enforcementPriority:
+        (taggingPolicy.find(tag => tag.key === currentTagGroup) || {})
+          .enforcement || 'non-policy',
       tagValue: '<tag not defined>',
       entityCount: this.props.entityCount - entityCount
     });

--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -228,12 +228,6 @@ export default class TagEntityView extends React.Component {
             ) {
               continue;
             } else {
-              // if (selectAllEntities && selectedTagKey && selectedTagValue) {
-              //   this.onSelectEntity(
-              //     { target: { checked: true } },
-              //     { item: { entityGuid: entity.guid } }
-              //   );
-              // }
               entities[entity.guid] = this.addEntity(entity, activeTagValue);
             }
           }
@@ -318,8 +312,6 @@ export default class TagEntityView extends React.Component {
     const {
       tagHierarchy,
       entityTagsMap,
-      // selectedTagKey,
-      // selectedTagValue
       reloadTagsFn
     } = this.props;
     const tagKeys = this.props.getTagKeys;
@@ -401,7 +393,6 @@ export default class TagEntityView extends React.Component {
               <Dropdown
                 title={firstTagKey}
                 items={tagKeys}
-                // disabled={selectedTagKey && selectedTagValue}
                 style={{
                   display: 'inline-block',
                   margin: '0 .5em',
@@ -430,7 +421,6 @@ export default class TagEntityView extends React.Component {
               <Dropdown
                 title={dropDownSelectedTagValue}
                 items={this.getTagValues()}
-                // disabled={selectedTagKey && selectedTagValue}
                 style={{
                   display: 'inline-block',
                   margin: '0 .5em',
@@ -461,7 +451,7 @@ export default class TagEntityView extends React.Component {
           <div className="button-section" style={{ padding: 8 }}>
             <ModalButton
               disabled={!operableEntities.length}
-              buttonText="Add Tags"
+              buttonText="Add tags"
               buttonType={Button.TYPE.PRIMARY}
             >
               <TagBulkAdd
@@ -473,7 +463,7 @@ export default class TagEntityView extends React.Component {
             </ModalButton>
             <ModalButton
               disabled={!operableEntities.length}
-              buttonText="Rename Tags"
+              buttonText="Rename tags"
               buttonType={Button.TYPE.PRIMARY}
             >
               <TagBulkRename
@@ -486,7 +476,7 @@ export default class TagEntityView extends React.Component {
             </ModalButton>
             <ModalButton
               disabled={!operableEntities.length}
-              buttonText="Change Values"
+              buttonText="Change values"
               buttonType={Button.TYPE.PRIMARY}
             >
               <TagBulkEdit
@@ -499,7 +489,7 @@ export default class TagEntityView extends React.Component {
             </ModalButton>
             <ModalButton
               disabled={!operableEntities.length}
-              buttonText="Remove Tags"
+              buttonText="Remove tags"
               buttonType={Button.TYPE.PRIMARY}
             >
               <TagBulkDelete

--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -343,15 +343,12 @@ export default class TagEntityView extends React.Component {
       };
       switch (entityDisplayOption) {
         case DISPLAY_OPTION.SPECIFIC_TAG_VALUE:
-          // eslint-disable-next-line prefer-template,prettier/prettier
           result += `with tag key: [${firstTagKey}] / tag value: [${dropDownSelectedTagValue}]`;
           break;
         case DISPLAY_OPTION.ALL_TAG_VALUES:
-          // eslint-disable-next-line prefer-template
           result += `with tag key: [${firstTagKey}] with any value`;
           break;
         case DISPLAY_OPTION.TAG_NOT_DEFINED:
-          // eslint-disable-next-line prefer-template
           result += `with tag key: [${firstTagKey}] not defined`;
           break;
         case DISPLAY_OPTION.ALL_ENTITIES:

--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -39,6 +39,7 @@ const DISPLAY_OPTION = {
 export default class TagEntityView extends React.Component {
   static propTypes = {
     tagHierarchy: PropTypes.object,
+    selectedEntityType: PropTypes.object,
     entityCount: PropTypes.number,
     entityTagsMap: PropTypes.object,
     getTagKeys: PropTypes.array,
@@ -330,7 +331,8 @@ export default class TagEntityView extends React.Component {
         entityDisplayOption,
         dropDownSelectedTagValue
       } = this.state;
-      let result = 'Showing entities ';
+      const { selectedEntityType } = this.props;
+      let result = `Showing entities for "${selectedEntityType.name}" entity type `;
 
       // showing entities with
       const DISPLAY_OPTION = {
@@ -342,18 +344,18 @@ export default class TagEntityView extends React.Component {
       switch (entityDisplayOption) {
         case DISPLAY_OPTION.SPECIFIC_TAG_VALUE:
           // eslint-disable-next-line prefer-template,prettier/prettier
-          result += 'with tag key: [' + firstTagKey + '] with tag value: [' + dropDownSelectedTagValue + ']';
+          result += `with tag key: [${firstTagKey}] / tag value: [${dropDownSelectedTagValue}]`;
           break;
         case DISPLAY_OPTION.ALL_TAG_VALUES:
           // eslint-disable-next-line prefer-template
-          result += 'with tag key: [' + firstTagKey + '] with any value';
+          result += `with tag key: [${firstTagKey}] with any value`;
           break;
         case DISPLAY_OPTION.TAG_NOT_DEFINED:
           // eslint-disable-next-line prefer-template
-          result += 'with tag key: [' + firstTagKey + '] not defined';
+          result += `with tag key: [${firstTagKey}] not defined`;
           break;
         case DISPLAY_OPTION.ALL_ENTITIES:
-          result = 'Showing all entities';
+          result = `Showing all entities for "${selectedEntityType.name}" entity type`;
           break;
       }
       return result;

--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -33,12 +33,14 @@ export default class TagEntityView extends React.Component {
   static propTypes = {
     tagHierarchy: PropTypes.object,
     entityTagsMap: PropTypes.object,
-    getTagKeys: PropTypes.object,
-    reloadTagsFn: PropTypes.func
+    getTagKeys: PropTypes.array,
+    reloadTagsFn: PropTypes.func,
+    selectedTagKey: PropTypes.string,
+    selectedTagValue: PropTypes.string
   };
 
   state = {
-    firstTagKey: 'account',
+    firstTagKey: this.props.selectedTagKey || 'account',
     table_column_1: TableHeaderCell.SORTING_TYPE.ASCENDING,
     selectedEntities: {},
     selectedEntityIds: [],
@@ -53,6 +55,15 @@ export default class TagEntityView extends React.Component {
         urlState.entityViewSortDirection ||
         TableHeaderCell.SORTING_TYPE.ASCENDING
     });
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      !this.props.selectedTagKey === prevProps.selectedTagKey ||
+      !this.props.selectedTagValue === prevProps.selectedTagValue
+    ) {
+      this.setState({ firstTagKey: this.props.selectedTagKey }); // eslint-disable-line react/no-did-update-set-state
+    }
   }
 
   static contextType = NerdletStateContext;
@@ -153,6 +164,7 @@ export default class TagEntityView extends React.Component {
         return 'mid__band';
       else return 'low__band';
     };
+
     return (
       <Grid className="primary-grid">
         <GridItem

--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -309,11 +309,7 @@ export default class TagEntityView extends React.Component {
       showAllTags,
       dropDownSelectedTagValue
     } = this.state;
-    const {
-      tagHierarchy,
-      entityTagsMap,
-      reloadTagsFn
-    } = this.props;
+    const { tagHierarchy, entityTagsMap, reloadTagsFn } = this.props;
     const tagKeys = this.props.getTagKeys;
     const entities = this.getTableData();
     const operableEntities = Object.keys(entityTagsMap).filter(entityId =>

--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -380,7 +380,7 @@ export default class TagEntityView extends React.Component {
         >
           <div>
             <div>
-              tag/value [
+              Key:Value [
               <Dropdown
                 title={firstTagKey}
                 items={tagKeys}
@@ -444,7 +444,7 @@ export default class TagEntityView extends React.Component {
           <div className="button-section" style={{ padding: 8 }}>
             <ModalButton
               disabled={!operableEntities.length}
-              buttonText="Add tags"
+              buttonText="Add Tags"
               buttonType={Button.TYPE.PRIMARY}
             >
               <TagBulkAdd
@@ -456,7 +456,7 @@ export default class TagEntityView extends React.Component {
             </ModalButton>
             <ModalButton
               disabled={!operableEntities.length}
-              buttonText="Rename tags"
+              buttonText="Rename Tags"
               buttonType={Button.TYPE.PRIMARY}
             >
               <TagBulkRename
@@ -469,7 +469,7 @@ export default class TagEntityView extends React.Component {
             </ModalButton>
             <ModalButton
               disabled={!operableEntities.length}
-              buttonText="Change values"
+              buttonText="Change Values"
               buttonType={Button.TYPE.PRIMARY}
             >
               <TagBulkEdit
@@ -482,7 +482,7 @@ export default class TagEntityView extends React.Component {
             </ModalButton>
             <ModalButton
               disabled={!operableEntities.length}
-              buttonText="Remove tags"
+              buttonText="Remove Tags"
               buttonType={Button.TYPE.PRIMARY}
             >
               <TagBulkDelete
@@ -534,7 +534,7 @@ export default class TagEntityView extends React.Component {
                 Score
               </TableHeaderCell>
               <TableHeaderCell width="6fr">
-                {showAllTags ? '' : 'Undefined'} Mandatory Tags
+                {showAllTags ? '' : 'Undefined'} Required Tags
               </TableHeaderCell>
               <TableHeaderCell width="7fr">
                 {showAllTags ? '' : 'Undefined'} Optional Tags

--- a/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-entity-view.js
@@ -50,6 +50,7 @@ export default class TagEntityView extends React.Component {
 
   state = {
     firstTagKey: this.props.selectedTagKey || 'account',
+    selectedEntityType: this.props.selectedEntityType,
     table_column_1: TableHeaderCell.SORTING_TYPE.ASCENDING,
     selectedEntities: {},
     selectedEntityIds: [],
@@ -57,6 +58,17 @@ export default class TagEntityView extends React.Component {
     dropDownSelectedTagValue: '',
     entityDisplayOption: DISPLAY_OPTION.SPECIFIC_TAG_VALUE // only show entities with tag value present
   };
+
+  static getDerivedStateFromProps(props, state) {
+    if (props.selectedEntityType.name !== state.selectedEntityType.name) {
+      return {
+        selectedEntityType: props.selectedEntityType,
+        dropDownSelectedTagValue: ''
+      };
+    } else {
+      return null;
+    }
+  }
 
   componentDidMount() {
     const urlState = this.context || {};
@@ -326,11 +338,7 @@ export default class TagEntityView extends React.Component {
     };
 
     const renderHeaderInfo = () => {
-      const {
-        firstTagKey,
-        entityDisplayOption,
-        dropDownSelectedTagValue
-      } = this.state;
+      const { firstTagKey, dropDownSelectedTagValue } = this.state;
       const { selectedEntityType } = this.props;
       let result = `Showing entities for "${selectedEntityType.name}" entity type `;
 
@@ -341,6 +349,15 @@ export default class TagEntityView extends React.Component {
         TAG_NOT_DEFINED: '3',
         ALL_ENTITIES: '4'
       };
+
+      let { entityDisplayOption } = this.state;
+      if (
+        entityDisplayOption === DISPLAY_OPTION.SPECIFIC_TAG_VALUE &&
+        !dropDownSelectedTagValue
+      ) {
+        entityDisplayOption = DISPLAY_OPTION.ALL_TAG_VALUES;
+      }
+
       switch (entityDisplayOption) {
         case DISPLAY_OPTION.SPECIFIC_TAG_VALUE:
           result += `with tag key: [${firstTagKey}] / tag value: [${dropDownSelectedTagValue}]`;

--- a/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
+++ b/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
@@ -70,12 +70,23 @@ $low-band-color: rgb(191, 0, 22);
     background-color: rgba(17, 166, 0, 0.05);
   }
 
-.tag__value__blank__row {
-  background-color: rgb(231, 181, 95);
+.tag__value__blank__row__required {
+  color: $low-band-color;
+  font-weight: 900;
+}
+
+.tag__value__blank__row__optional {
+  color: $mid-band-color;
+  font-weight: 900;
+}
+
+.tag__value__blank__row__non-policy {
+  color: black;
+  font-weight: 900;
 }
 
 .tag__value__normal__row {
-  background-color: white;
+  color: initial;
 }
 
 .tag__analyzer__selected__row {

--- a/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
+++ b/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
@@ -69,3 +69,11 @@ $low-band-color: rgb(191, 0, 22);
     color: $high-band-color;
     background-color: rgba(17, 166, 0, 0.05);
   }
+
+.tag__value__blank__row {
+  background-color: rgb(231, 181, 95);
+}
+
+.tag__value__normal__row {
+  background-color: white;
+}

--- a/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
+++ b/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
@@ -77,3 +77,11 @@ $low-band-color: rgb(191, 0, 22);
 .tag__value__normal__row {
   background-color: white;
 }
+
+.tag__analyzer__selected__row {
+  background-color: #e0ece0;
+}
+
+.tag__analyzer__normal__row {
+  background-color: #ffffff;
+}

--- a/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
+++ b/nerdlets/tag-improver-nerdlet/components/tag-listing.scss
@@ -83,5 +83,5 @@ $low-band-color: rgb(191, 0, 22);
 }
 
 .tag__analyzer__normal__row {
-  background-color: #ffffff;
+  text-decoration-color: initial;
 }

--- a/nerdlets/tag-improver-nerdlet/components/tag-policy.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-policy.js
@@ -110,19 +110,6 @@ export default class TaggingPolicy extends React.Component {
     });
   };
 
-  onChangeLabel = index => e => {
-    const { workingSchema } = this.state;
-    const itemAtIndex = workingSchema[index];
-    const newItem = { ...itemAtIndex, label: e.currentTarget.value };
-    this.setState({
-      workingSchema: [
-        ...workingSchema.slice(0, index),
-        newItem,
-        ...workingSchema.slice(index + 1, workingSchema.length)
-      ]
-    });
-  };
-
   onChangeEnforcement = index => (_, value) => {
     const { workingSchema } = this.state;
     const itemAtIndex = workingSchema[index];
@@ -193,15 +180,6 @@ export default class TaggingPolicy extends React.Component {
       savingPolicy,
       tableSorting
     } = this.state;
-    /*
-    {
-        label: 'Owning team',
-        key: 'Team',
-        purpose: '',
-        enforcement: TAG_SCHEMA_ENFORCEMENT.required,
-        allowedValues: [],
-    },
-    */
 
     if (!schema) {
       return <Spinner />;
@@ -283,20 +261,6 @@ export default class TaggingPolicy extends React.Component {
         <Table items={isEditMode ? workingSchema : schema}>
           <TableHeader>
             <TableHeaderCell
-              width="200px"
-              sortable={!isEditMode}
-              sortingOrder={4}
-              value={({ item }) => item.label}
-              onClick={this.onClickTableHeaderCell('label')}
-              sortingType={
-                isEditMode
-                  ? TableHeaderCell.SORTING_TYPE.NONE
-                  : tableSorting.label
-              }
-            >
-              Name
-            </TableHeaderCell>
-            <TableHeaderCell
               width="150px"
               sortable={!isEditMode}
               sortingOrder={3}
@@ -363,7 +327,7 @@ export default class TaggingPolicy extends React.Component {
             </TableHeaderCell>
             <TableHeaderCell
               sortable={!isEditMode}
-              sortingOrder={5}
+              sortingOrder={4}
               value={({ item }) => item.purpose}
               onClick={this.onClickTableHeaderCell('purpose')}
               sortingType={
@@ -379,16 +343,6 @@ export default class TaggingPolicy extends React.Component {
 
           {({ item, index }) => (
             <TableRow>
-              <TableRowCell>
-                {isEditMode ? (
-                  <TextField
-                    onChange={this.onChangeLabel(index)}
-                    value={item.label}
-                  />
-                ) : (
-                  item.label
-                )}
-              </TableRowCell>
               <TableRowCell>
                 {isEditMode ? (
                   <Autocomplete

--- a/nerdlets/tag-improver-nerdlet/components/tag-policy.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-policy.js
@@ -143,7 +143,6 @@ export default class TaggingPolicy extends React.Component {
         ...workingSchema,
         {
           key: '',
-          label: '',
           enforcement: TAG_SCHEMA_ENFORCEMENT.optional,
           purpose: ''
         }

--- a/nerdlets/tag-improver-nerdlet/components/tag-policy.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-policy.js
@@ -271,7 +271,7 @@ export default class TaggingPolicy extends React.Component {
                   : tableSorting.key
               }
             >
-              Tag key
+              Key
             </TableHeaderCell>
             <TableHeaderCell
               width="200px"
@@ -285,7 +285,7 @@ export default class TaggingPolicy extends React.Component {
                   : tableSorting.enforcement
               }
             >
-              Enforcement level
+              Enforcement Level
             </TableHeaderCell>
             <TableHeaderCell
               width="100px"
@@ -322,7 +322,7 @@ export default class TaggingPolicy extends React.Component {
                   : tableSorting.count
               }
             >
-              Entity count
+              Entity Count
             </TableHeaderCell>
             <TableHeaderCell
               sortable={!isEditMode}

--- a/nerdlets/tag-improver-nerdlet/components/tag-policy.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-policy.js
@@ -86,7 +86,11 @@ export default class TaggingPolicy extends React.Component {
   startEditing = () => {
     const { schema } = this.props;
     const workingSchema = schema.map(schemaRule => ({ ...schemaRule }));
-    this.setState({ isEditMode: true, workingSchema, savedSchema: workingSchema });
+    this.setState({
+      isEditMode: true,
+      workingSchema,
+      savedSchema: workingSchema
+    });
   };
 
   cancelEditing = () => {

--- a/nerdlets/tag-improver-nerdlet/components/tag-policy.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-policy.js
@@ -46,6 +46,7 @@ export default class TaggingPolicy extends React.Component {
     super(props);
     this.state = {
       workingSchema: null,
+      savedSchema: null,
       isEditMode: false,
       savingPolicy: false,
       policySaveErrored: false,
@@ -58,7 +59,7 @@ export default class TaggingPolicy extends React.Component {
 
   applyEdits = () => {
     const { updatePolicy } = this.props;
-    const { workingSchema: policy } = this.state;
+    const { workingSchema: policy, savedSchema } = this.state;
     this.setState({ savingPolicy: true });
     UserStorageMutation.mutate({
       actionType: UserStorageMutation.ACTION_TYPE.WRITE_DOCUMENT,
@@ -74,7 +75,7 @@ export default class TaggingPolicy extends React.Component {
             savingPolicy: false,
             policySaveErrored: false
           },
-          () => updatePolicy(policy)
+          () => updatePolicy(policy, savedSchema)
         );
       })
       .catch(() => {
@@ -85,7 +86,7 @@ export default class TaggingPolicy extends React.Component {
   startEditing = () => {
     const { schema } = this.props;
     const workingSchema = schema.map(schemaRule => ({ ...schemaRule }));
-    this.setState({ isEditMode: true, workingSchema });
+    this.setState({ isEditMode: true, workingSchema, savedSchema: workingSchema });
   };
 
   cancelEditing = () => {

--- a/nerdlets/tag-improver-nerdlet/components/tag-policy.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-policy.js
@@ -285,7 +285,7 @@ export default class TaggingPolicy extends React.Component {
                   : tableSorting.enforcement
               }
             >
-              Enforcement Level
+              Enforcement level
             </TableHeaderCell>
             <TableHeaderCell
               width="100px"
@@ -322,7 +322,7 @@ export default class TaggingPolicy extends React.Component {
                   : tableSorting.count
               }
             >
-              Entity Count
+              Entity count
             </TableHeaderCell>
             <TableHeaderCell
               sortable={!isEditMode}

--- a/nerdlets/tag-improver-nerdlet/components/tag-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-table.js
@@ -51,7 +51,7 @@ export default class TagTable extends React.Component {
             sortingOrder={2}
             onClick={(a, b) => setSortingColumn(1, a, b)}
           >
-            Enforcement Level
+            Enforcement level
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.cardinality}
@@ -60,7 +60,7 @@ export default class TagTable extends React.Component {
             sortingOrder={3}
             onClick={(a, b) => setSortingColumn(2, a, b)}
           >
-            Distinct Values
+            Distinct values
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.entityCount}
@@ -69,7 +69,7 @@ export default class TagTable extends React.Component {
             sortingOrder={4}
             onClick={(a, b) => setSortingColumn(3, a, b)}
           >
-            Entity Count
+            Entity count
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.entityPercent}

--- a/nerdlets/tag-improver-nerdlet/components/tag-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-table.js
@@ -42,7 +42,7 @@ export default class TagTable extends React.Component {
             sortingOrder={1}
             onClick={(a, b) => setSortingColumn(0, a, b)}
           >
-            Tag name
+            Tag key
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.enforcement}
@@ -51,7 +51,7 @@ export default class TagTable extends React.Component {
             sortingOrder={2}
             onClick={(a, b) => setSortingColumn(1, a, b)}
           >
-            Enforcement Level
+            Enforcement level
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.cardinality}
@@ -69,7 +69,7 @@ export default class TagTable extends React.Component {
             sortingOrder={4}
             onClick={(a, b) => setSortingColumn(3, a, b)}
           >
-            Tagged entities
+            Entity count
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.entityPercent}

--- a/nerdlets/tag-improver-nerdlet/components/tag-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-table.js
@@ -42,7 +42,7 @@ export default class TagTable extends React.Component {
             sortingOrder={1}
             onClick={(a, b) => setSortingColumn(0, a, b)}
           >
-            Tag key
+            Key
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.enforcement}
@@ -51,7 +51,7 @@ export default class TagTable extends React.Component {
             sortingOrder={2}
             onClick={(a, b) => setSortingColumn(1, a, b)}
           >
-            Enforcement level
+            Enforcement Level
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.cardinality}
@@ -60,7 +60,7 @@ export default class TagTable extends React.Component {
             sortingOrder={3}
             onClick={(a, b) => setSortingColumn(2, a, b)}
           >
-            Distinct values
+            Distinct Values
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.entityCount}
@@ -69,7 +69,7 @@ export default class TagTable extends React.Component {
             sortingOrder={4}
             onClick={(a, b) => setSortingColumn(3, a, b)}
           >
-            Entity count
+            Entity Count
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.entityPercent}
@@ -78,7 +78,7 @@ export default class TagTable extends React.Component {
             sortingOrder={5}
             onClick={(a, b) => setSortingColumn(4, a, b)}
           >
-            % coverage
+            Coverage
           </TableHeaderCell>
         </TableHeader>
 
@@ -131,7 +131,7 @@ export default class TagTable extends React.Component {
                   : 'tag__analyzer__normal__row'
               }
             >
-              {item.entityPercent}
+              {item.entityPercent}%
             </TableRowCell>
           </TableRow>
         )}

--- a/nerdlets/tag-improver-nerdlet/components/tag-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-table.js
@@ -54,6 +54,7 @@ export default class TagTable extends React.Component {
             Enforcement level
           </TableHeaderCell>
           <TableHeaderCell
+            alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
             value={({ item }) => item.cardinality}
             sortable
             sortingType={this.state.tag_column_2}
@@ -63,6 +64,7 @@ export default class TagTable extends React.Component {
             Distinct values
           </TableHeaderCell>
           <TableHeaderCell
+            alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
             value={({ item }) => item.entityCount}
             sortable
             sortingType={this.state.tag_column_3}
@@ -72,6 +74,7 @@ export default class TagTable extends React.Component {
             Entity count
           </TableHeaderCell>
           <TableHeaderCell
+            alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
             value={({ item }) => item.entityPercent}
             sortable
             sortingType={this.state.tag_column_4}

--- a/nerdlets/tag-improver-nerdlet/components/tag-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-table.js
@@ -107,6 +107,7 @@ export default class TagTable extends React.Component {
               {item.enforcement}
             </TableRowCell>
             <TableRowCell
+              alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
               className={
                 item.selected
                   ? 'tag__analyzer__selected__row'
@@ -116,6 +117,7 @@ export default class TagTable extends React.Component {
               {item.cardinality}
             </TableRowCell>
             <TableRowCell
+              alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
               className={
                 item.selected
                   ? 'tag__analyzer__selected__row'
@@ -125,6 +127,7 @@ export default class TagTable extends React.Component {
               {item.entityCount}
             </TableRowCell>
             <TableRowCell
+              alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
               className={
                 item.selected
                   ? 'tag__analyzer__selected__row'

--- a/nerdlets/tag-improver-nerdlet/components/tag-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-table.js
@@ -88,11 +88,51 @@ export default class TagTable extends React.Component {
               this.props.selectTag(item.tagKey);
             }}
           >
-            <TableRowCell>{item.tagKey}</TableRowCell>
-            <TableRowCell>{item.enforcement}</TableRowCell>
-            <TableRowCell>{item.cardinality}</TableRowCell>
-            <TableRowCell>{item.entityCount}</TableRowCell>
-            <TableRowCell>{item.entityPercent}</TableRowCell>
+            <TableRowCell
+              className={
+                item.selected
+                  ? 'tag__analyzer__selected__row'
+                  : 'tag__analyzer__normal__row'
+              }
+            >
+              {item.tagKey}
+            </TableRowCell>
+            <TableRowCell
+              className={
+                item.selected
+                  ? 'tag__analyzer__selected__row'
+                  : 'tag__analyzer__normal__row'
+              }
+            >
+              {item.enforcement}
+            </TableRowCell>
+            <TableRowCell
+              className={
+                item.selected
+                  ? 'tag__analyzer__selected__row'
+                  : 'tag__analyzer__normal__row'
+              }
+            >
+              {item.cardinality}
+            </TableRowCell>
+            <TableRowCell
+              className={
+                item.selected
+                  ? 'tag__analyzer__selected__row'
+                  : 'tag__analyzer__normal__row'
+              }
+            >
+              {item.entityCount}
+            </TableRowCell>
+            <TableRowCell
+              className={
+                item.selected
+                  ? 'tag__analyzer__selected__row'
+                  : 'tag__analyzer__normal__row'
+              }
+            >
+              {item.entityPercent}
+            </TableRowCell>
           </TableRow>
         )}
       </Table>

--- a/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
@@ -56,6 +56,7 @@ export default class TagValueTable extends React.Component {
             Tag value
           </TableHeaderCell>
           <TableHeaderCell
+            alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
             value={({ item }) => item.entityCount}
             sortable
             sortingType={this.state.value_column_1}
@@ -74,7 +75,7 @@ export default class TagValueTable extends React.Component {
             <TableRowCell
               className={
                 item.tagValue === '<tag not defined>' && item.entityCount
-                  ? 'tag__value__blank__row'
+                  ? `tag__value__blank__row__${item.enforcementPriority}`
                   : 'tag__value__normal__row'
               }
             >
@@ -84,7 +85,7 @@ export default class TagValueTable extends React.Component {
               alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
               className={
                 item.tagValue === '<tag not defined>' && item.entityCount
-                  ? 'tag__value__blank__row'
+                  ? `tag__value__blank__row__${item.enforcementPriority}`
                   : 'tag__value__normal__row'
               }
             >

--- a/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
@@ -53,7 +53,7 @@ export default class TagValueTable extends React.Component {
             sortingOrder={1}
             onClick={(a, b) => setSortingColumn(0, a, b)}
           >
-            Tag Value
+            Tag value
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.entityCount}
@@ -62,10 +62,10 @@ export default class TagValueTable extends React.Component {
             sortingOrder={2}
             onClick={(a, b) => setSortingColumn(1, a, b)}
           >
-            Entity Count
+            Entity count
           </TableHeaderCell>
           <TableHeaderCell value={({ item }) => item}>
-            Manage Entities
+            Manage entities
           </TableHeaderCell>
         </TableHeader>
 

--- a/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
@@ -11,7 +11,8 @@ import {
 
 export default class TagValueTable extends React.Component {
   static propTypes = {
-    getTableData: PropTypes.func
+    getTableData: PropTypes.func,
+    onShowEntities: PropTypes.func
   };
 
   constructor(props) {
@@ -20,6 +21,10 @@ export default class TagValueTable extends React.Component {
       value_column_0: TableHeaderCell.SORTING_TYPE.ASCENDING
     };
   }
+
+  openEntities = item => {
+    this.props.onShowEntities(item);
+  };
 
   setSortingColumn = (columnId, event, sortingData) => {
     const nextType = sortingData ? sortingData.nextSortingType : undefined;
@@ -32,7 +37,7 @@ export default class TagValueTable extends React.Component {
   };
 
   render() {
-    const { setSortingColumn } = this;
+    const { setSortingColumn, openEntities } = this;
 
     return (
       <Table items={this.props.getTableData()}>
@@ -55,12 +60,18 @@ export default class TagValueTable extends React.Component {
           >
             Tagged entities
           </TableHeaderCell>
+          <TableHeaderCell value={({ item }) => item}>
+            Manage entities
+          </TableHeaderCell>
         </TableHeader>
 
         {({ item }) => (
           <TableRow>
             <TableRowCell>{item.tagValue}</TableRowCell>
             <TableRowCell>{item.entityCount}</TableRowCell>
+            <TableRowCell>
+              <a onClick={() => openEntities(item)}>manage</a>
+            </TableRowCell>
           </TableRow>
         )}
       </Table>

--- a/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
@@ -62,7 +62,7 @@ export default class TagValueTable extends React.Component {
             sortingOrder={2}
             onClick={(a, b) => setSortingColumn(1, a, b)}
           >
-            Tagged entities
+            Entity count
           </TableHeaderCell>
           <TableHeaderCell value={({ item }) => item}>
             Manage entities

--- a/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
@@ -73,7 +73,7 @@ export default class TagValueTable extends React.Component {
           <TableRow>
             <TableRowCell
               className={
-                item.tagValue === '<not present>' && item.entityCount
+                item.tagValue === '<tag not defined>' && item.entityCount
                   ? 'tag__value__blank__row'
                   : 'tag__value__normal__row'
               }
@@ -82,7 +82,7 @@ export default class TagValueTable extends React.Component {
             </TableRowCell>
             <TableRowCell
               className={
-                item.tagValue === '<not present>' && item.entityCount
+                item.tagValue === '<tag not defined>' && item.entityCount
                   ? 'tag__value__blank__row'
                   : 'tag__value__normal__row'
               }

--- a/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
@@ -40,7 +40,11 @@ export default class TagValueTable extends React.Component {
     const { setSortingColumn, openEntities } = this;
 
     return (
-      <Table items={this.props.getTableData()}>
+      <Table
+        items={this.props.getTableData().filter(item => {
+          return item.entityCount > 0;
+        })}
+      >
         <TableHeader>
           <TableHeaderCell
             value={({ item }) => item.tagValue}
@@ -67,10 +71,30 @@ export default class TagValueTable extends React.Component {
 
         {({ item }) => (
           <TableRow>
-            <TableRowCell>{item.tagValue}</TableRowCell>
-            <TableRowCell>{item.entityCount}</TableRowCell>
+            <TableRowCell
+              className={
+                item.tagValue === '<not present>' && item.entityCount
+                  ? 'tag__value__blank__row'
+                  : 'tag__value__normal__row'
+              }
+            >
+              {item.tagValue}
+            </TableRowCell>
+            <TableRowCell
+              className={
+                item.tagValue === '<not present>' && item.entityCount
+                  ? 'tag__value__blank__row'
+                  : 'tag__value__normal__row'
+              }
+            >
+              {item.entityCount}
+            </TableRowCell>
             <TableRowCell>
-              <a onClick={() => openEntities(item)}>manage</a>
+              {item.entityCount ? (
+                <a onClick={() => openEntities(item)}>manage</a>
+              ) : (
+                ''
+              )}
             </TableRowCell>
           </TableRow>
         )}

--- a/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
@@ -53,7 +53,7 @@ export default class TagValueTable extends React.Component {
             sortingOrder={1}
             onClick={(a, b) => setSortingColumn(0, a, b)}
           >
-            Tag value
+            Tag Value
           </TableHeaderCell>
           <TableHeaderCell
             value={({ item }) => item.entityCount}
@@ -62,10 +62,10 @@ export default class TagValueTable extends React.Component {
             sortingOrder={2}
             onClick={(a, b) => setSortingColumn(1, a, b)}
           >
-            Entity count
+            Entity Count
           </TableHeaderCell>
           <TableHeaderCell value={({ item }) => item}>
-            Manage entities
+            Manage Entities
           </TableHeaderCell>
         </TableHeader>
 
@@ -91,7 +91,7 @@ export default class TagValueTable extends React.Component {
             </TableRowCell>
             <TableRowCell>
               {item.entityCount ? (
-                <a onClick={() => openEntities(item)}>manage</a>
+                <a onClick={() => openEntities(item)}>Manage</a>
               ) : (
                 ''
               )}

--- a/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
+++ b/nerdlets/tag-improver-nerdlet/components/tag-value-table.js
@@ -81,6 +81,7 @@ export default class TagValueTable extends React.Component {
               {item.tagValue}
             </TableRowCell>
             <TableRowCell
+              alignmentType={TableRowCell.ALIGNMENT_TYPE.RIGHT}
               className={
                 item.tagValue === '<tag not defined>' && item.entityCount
                   ? 'tag__value__blank__row'

--- a/nerdlets/tag-improver-nerdlet/index.js
+++ b/nerdlets/tag-improver-nerdlet/index.js
@@ -115,6 +115,8 @@ export default class TagVisualizer extends React.Component {
       queryCursor: undefined,
       accountId: null,
       taggingPolicy: null,
+      selectedTagKey: '',
+      selectedTagValue: '',
       mandatoryTagCount: 0
     });
   };

--- a/nerdlets/tag-improver-nerdlet/index.js
+++ b/nerdlets/tag-improver-nerdlet/index.js
@@ -41,8 +41,8 @@ export default class TagVisualizer extends React.Component {
       name: 'Application',
       value: 'APM_APPLICATION_ENTITY'
     },
-    selectedTagKey: null,
-    selectedTagValue: null,
+    selectedTagKey: '',
+    selectedTagValue: '',
     currentTab: 'policy-tab'
   };
 
@@ -76,7 +76,14 @@ export default class TagVisualizer extends React.Component {
 
   onChangeTab = newTab => {
     nerdlet.setUrlState({ tab: newTab });
-    this.setState({ currentTab: newTab });
+    this.setState({ currentTab: newTab }, () => {
+      if (newTab !== 'entity-tab') {
+        this.setState({
+          // selectedTagKey: '',
+          selectedTagValue: ''
+        });
+      }
+    });
   };
 
   onUpdateEntitiesFilter = item => {
@@ -129,8 +136,8 @@ export default class TagVisualizer extends React.Component {
         loadedEntities: 0,
         doneLoading: false,
         queryCursor: undefined,
-        selectedTagKey: null,
-        selectedTagValue: null
+        selectedTagKey: '',
+        selectedTagValue: ''
       },
       () => {
         loadEntityBatch();

--- a/nerdlets/tag-improver-nerdlet/index.js
+++ b/nerdlets/tag-improver-nerdlet/index.js
@@ -345,7 +345,10 @@ export default class TagVisualizer extends React.Component {
         const { updateEntityTagCompliance } = this;
 
         // check if policy was changed
-        if (JSON.stringify(policy) !== JSON.stringify(prevPolicy)) {
+        if (
+          JSON.stringify(sortedPolicy(policy)) !==
+          JSON.stringify(sortedPolicy(prevPolicy))
+        ) {
           // add new policy tags to tagHierarchy if not present (not likely)
           for (const tag of policy) {
             if (!tagHierarchy[tag.key]) tagHierarchy[tag.key] = {};

--- a/nerdlets/tag-improver-nerdlet/index.js
+++ b/nerdlets/tag-improver-nerdlet/index.js
@@ -264,14 +264,14 @@ export default class TagVisualizer extends React.Component {
       this.updateEntityTagCompliance(entity, taggingPolicy, mandatoryTagCount);
 
       // for each tag, if it doesn't make an empty object
-      tags.forEach(({ tagKey, tagValues }) => {
-        if (!acc[tagKey]) acc[tagKey] = {};
+      for (const tag of tags) {
+        if (!acc[tag.tagKey]) acc[tag.tagKey] = {};
         // for each tag value, check if it exists, if it doesn't make it an empty object
-        tagValues.forEach(value => {
-          if (!acc[tagKey][value]) acc[tagKey][value] = [];
-          acc[tagKey][value].push(entity);
-        });
-      });
+        for (const value of tag.tagValues) {
+          if (!acc[tag.tagKey][value]) acc[tag.tagKey][value] = [];
+          acc[tag.tagKey][value].push(entity);
+        }
+      }
       return acc;
     }, tagHierarchy);
 
@@ -340,13 +340,13 @@ export default class TagVisualizer extends React.Component {
       () => {
         const { tagHierarchy, mandatoryTagCount } = this.state;
         const { updateEntityTagCompliance } = this;
-        Object.entries(tagHierarchy).forEach(tagKey => {
-          Object.values(tagKey[1]).forEach(tagValue => {
-            tagValue.forEach(entity => {
+        for (const tagKey of Object.entries(tagHierarchy)) {
+          for (const tagValue of Object.values(tagKey[1])) {
+            for (const entity of tagValue) {
               updateEntityTagCompliance(entity, policy, mandatoryTagCount);
-            });
-          });
-        });
+            }
+          }
+        }
       }
     );
   };

--- a/nerdlets/tag-improver-nerdlet/index.js
+++ b/nerdlets/tag-improver-nerdlet/index.js
@@ -350,8 +350,13 @@ export default class TagVisualizer extends React.Component {
           }
           // remove tags that were removed from ploicy and are not used by any entity
           for (const tag of prevPolicy) {
-            if (!policy.find(policyTag => {return policyTag.key === tag.key}))
-              if (!Object.keys(tagHierarchy[tag.key]).length) delete tagHierarchy[tag.key];
+            if (
+              !policy.find(policyTag => {
+                return policyTag.key === tag.key;
+              })
+            )
+              if (!Object.keys(tagHierarchy[tag.key]).length)
+                delete tagHierarchy[tag.key];
           }
         }
 

--- a/nerdlets/tag-improver-nerdlet/index.js
+++ b/nerdlets/tag-improver-nerdlet/index.js
@@ -40,7 +40,10 @@ export default class TagVisualizer extends React.Component {
       id: 'APM',
       name: 'Application',
       value: 'APM_APPLICATION_ENTITY'
-    }
+    },
+    selectedTagKey: null,
+    selectedTagValue: null,
+    currentTab: 'policy-tab'
   };
 
   componentDidMount() {
@@ -73,6 +76,21 @@ export default class TagVisualizer extends React.Component {
 
   onChangeTab = newTab => {
     nerdlet.setUrlState({ tab: newTab });
+    this.setState({ currentTab: newTab });
+  };
+
+  onUpdateEntitiesFilter = item => {
+    this.setState({
+      selectedTagKey: item.tagKey,
+      selectedTagValue: item.tagValue
+    });
+  };
+
+  onShowEntities = item => {
+    this.onUpdateEntitiesFilter(item);
+    this.setState({
+      currentTab: 'entity-tab'
+    });
   };
 
   updateSelectedEntityType = entityType => {
@@ -110,7 +128,9 @@ export default class TagVisualizer extends React.Component {
         entityCount: 0,
         loadedEntities: 0,
         doneLoading: false,
-        queryCursor: undefined
+        queryCursor: undefined,
+        selectedTagKey: null,
+        selectedTagValue: null
       },
       () => {
         loadEntityBatch();
@@ -223,6 +243,12 @@ export default class TagVisualizer extends React.Component {
       taggingPolicy,
       mandatoryTagCount
     } = this.state;
+
+    if (!Object.keys(tagHierarchy).length) {
+      for (const tag of taggingPolicy) {
+        tagHierarchy[tag.key] = {};
+      }
+    }
     entities.reduce((acc, entity) => {
       // get all the tags
       const { guid, tags } = entity;
@@ -327,7 +353,10 @@ export default class TagVisualizer extends React.Component {
       entityTagsMap,
       taggingPolicy,
       accountId,
-      selectedEntityType
+      selectedEntityType,
+      selectedTagKey,
+      selectedTagValue,
+      currentTab
     } = this.state;
 
     return (
@@ -369,6 +398,7 @@ export default class TagVisualizer extends React.Component {
 
               <Tabs
                 defaultValue={(nerdletState || {}).tab || 'overview-tab'}
+                value={currentTab}
                 onChange={this.onChangeTab}
               >
                 <TabsItem value="policy-tab" label="Policy">
@@ -393,6 +423,8 @@ export default class TagVisualizer extends React.Component {
                     taggingPolicy={taggingPolicy}
                     getTagKeys={getTagKeys(tagHierarchy, taggingPolicy)}
                     height={this.props.height}
+                    onUpdateEntitiesFilter={this.onUpdateEntitiesFilter}
+                    onShowEntities={this.onShowEntities}
                   />
                 </TabsItem>
                 <TabsItem value="entity-tab" label="Entities">
@@ -405,6 +437,8 @@ export default class TagVisualizer extends React.Component {
                     entityTagsMap={entityTagsMap}
                     reloadTagsFn={this.startLoadingEntityTags}
                     getTagKeys={getTagKeys(tagHierarchy, taggingPolicy)}
+                    selectedTagKey={selectedTagKey}
+                    selectedTagValue={selectedTagValue}
                   />
                 </TabsItem>
               </Tabs>

--- a/nerdlets/tag-improver-nerdlet/tag-schema.js
+++ b/nerdlets/tag-improver-nerdlet/tag-schema.js
@@ -21,14 +21,12 @@ const COMPLIANCEBANDS = {
 
 const SCHEMA = [
   {
-    label: 'Owning team',
     key: 'Team',
     purpose: 'What team owns this entity?',
     enforcement: TAG_SCHEMA_ENFORCEMENT.required,
     allowedValues: [] // reserved for future use
   },
   {
-    label: 'Environment',
     key: 'Environment',
     purpose:
       'Is this entity part of your production, pre-prod, test, dev, or other environment?',
@@ -36,14 +34,12 @@ const SCHEMA = [
     allowedValues: [] // reserved for future use
   },
   {
-    label: 'Business application',
     key: 'Application',
     purpose: 'What business application/area/line is this entity part of?',
     enforcement: TAG_SCHEMA_ENFORCEMENT.optional,
     allowedValues: [] // reserved for future use
   },
   {
-    label: 'Chat channel',
     key: 'Chat',
     purpose:
       'What Slack/Teams/chat channel do I go to with questions about this entity?',
@@ -51,7 +47,6 @@ const SCHEMA = [
     allowedValues: [] // reserved for future use
   },
   {
-    label: 'Region / AZ / Datacenter',
     key: 'Region',
     purpose:
       'What region/availability zone/datacenter is this entity deployed in?',


### PR DESCRIPTION
- add entities links
- feat: v1.1-tag-analyzer-links - filter entities by selected tag key/value
- display entities with missing tags
- in Tag Analyzer tab change selected tag's row background color
- change the selected row on the left if different tag selected from dropdown on the right
- entity display options - show entities based on options selected on top
- add header info to Entity tab to indicate what is displayed
- change selected row's background color
- performance improvement
